### PR TITLE
Removes id parameter from __init__()

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,8 +363,8 @@ So, we'll keep our `__init__` and `save()` methods separate:
 ```py
 class Song:
 
-    def __init__(self, name, album, id=None):
-        self.id = id
+    def __init__(self, name, album):
+        self.id = None
         self.name = name
         self.album = album
 


### PR DESCRIPTION
The id attribute shouldn't be writable by the user, which is stated in the lesson. But the example on line 366 indicates the opposite, so correcting for consistency. 