### PR TITLE
Add missing .new for creating a Song in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ database as one, single row.
 For example, let's say we have a song:
 
 ```py
-blinding_lights = Song("Blinding Lights", "After Hours")
+blinding_lights = Song.new("Blinding Lights", "After Hours")
 
 blinding_lights.name
 # => "Blinding Lights"


### PR DESCRIPTION
`blinding_lights = Song.new("Blinding Lights", "After Hours")`

instead of 

`blinding_lights = Song("Blinding Lights", "After Hours")`

The example below uses `.new` but this one doesn't. Not sure how much this matters or if it's intentional. Feel free to fill me in here if I'm missing something 🙏 