### PR TITLE
fixes test_creates_and_returns song

### DIFF
--- a/lib/song.py
+++ b/lib/song.py
@@ -2,3 +2,4 @@ from config import CONN, CURSOR
 
 class Song:
     pass
+

--- a/lib/song.py
+++ b/lib/song.py
@@ -2,4 +2,3 @@ from config import CONN, CURSOR
 
 class Song:
     pass
-

--- a/lib/testing/class_test.py
+++ b/lib/testing/class_test.py
@@ -16,6 +16,11 @@ class TestClass:
 
     def test_saves_song_to_table(self):
         '''has instancemethod "save()" that saves a song to music.db.'''
+
+        
+        CURSOR.execute('''DROP TABLE IF EXISTS songs''')
+        Song.create_table()
+
         song = Song("Hold On", "Born to Sing")
         song.save()
         db_song = CURSOR.execute(
@@ -35,4 +40,5 @@ class TestClass:
             'SELECT * FROM songs WHERE name=? AND album=?',
             ('Hold On', 'Born to Sing')
         ).fetchone()
+
         assert(db_song[0] == song.id and db_song[1] == song.name and db_song[2] == song.album)

--- a/lib/testing/class_test.py
+++ b/lib/testing/class_test.py
@@ -24,11 +24,15 @@ class TestClass:
         ).fetchone()
         assert(db_song[1] == song.name and db_song[2] == song.album)
 
-    def creates_and_returns_song(self):
+    def test_creates_and_returns_song(self):
         '''has classmethod "create()" that creates a Song instance, saves it, and returns it.'''
+
+        CURSOR.execute('''DROP TABLE IF EXISTS songs''')
+        Song.create_table()
+
         song = Song.create("Hold On", "Born to Sing")
         db_song = CURSOR.execute(
             'SELECT * FROM songs WHERE name=? AND album=?',
             ('Hold On', 'Born to Sing')
         ).fetchone()
-        assert(db_song[0] == song[0] and db_song[1] == song[1] and db_song[2] == song[2])
+        assert(db_song[0] == song.id and db_song[1] == song.name and db_song[2] == song.album)


### PR DESCRIPTION
The last test wasn't working without the "test" piece of its name. Further the current test was trying to index into the song object. The last piece that was interesting was that the ids weren't matching. This is likely because in the previous test we create the same Song instance and save it to our database. Thus, when we grab the song from our database again we get an id of 1 from our database and id of 2 from our song instance. 

Fix here is to drop the old table and create a new table. A better approach would probably be to create a completely different song so we don't need to drop and recreate the table. For now though, this works.

That being said, the latest commit has changed the __init__.py in lib to config.py and all of its relative imports. In that current state, I am not able to get all of the tests passing for some reason. However when I use __init__.py, the solution code works!

Would love to discuss